### PR TITLE
httr::config

### DIFF
--- a/R/redcapConnection.R
+++ b/R/redcapConnection.R
@@ -73,7 +73,7 @@
 #' 
 
 redcapConnection <-
-function(url=getOption('redcap_api_url'),token,conn,project, config=list())
+function(url=getOption('redcap_api_url'),token,conn,project, config=httr::config())
 {
    if (is.na(url) && missing(conn))
       stop("Need one of url or conn")


### PR DESCRIPTION
@nutterb & @SteveLane
It's my understanding that this is the recommended way to pass config options to httr.  Otherwise, you sometimes get errors like
```r
> redcapAPI::exportRecords(rcon)
Error: is.request(y) is not TRUE
```

That `httr::config()` function creates a list that also of class `request`:
```r
> class(httr::config())
[1] "request"
```