### PR TITLE
Improper handling of 'time' values by sapply

### DIFF
--- a/R/validateImport.R
+++ b/R/validateImport.R
@@ -293,7 +293,7 @@ validateImport <- function(field, meta_data, records, ids,
   #* convert times to character to ensure valid format
     x <- as.character(x)
     w <- which(!grepl("(00:\\d{2}:\\d{2}|\\d{2}:\\d{2})", x) & !is.na(x))
-    x <- sapply(strsplit(x, ":"), utils::tail, 2)
+    x <- lapply(strsplit(x, ":"), utils::tail, 2)
     x <- sapply(x, paste, collapse=":")
     if (length(w) > 0){
       not_time_mmss_msg <- records[w, c(ids, field), drop=FALSE]
@@ -326,7 +326,7 @@ validateImport <- function(field, meta_data, records, ids,
     
     # Convert to character again for upload.
     x <- as.character(x)
-    x <- sapply(strsplit(x, ":"), utils::tail, 2)
+    x <- lapply(strsplit(x, ":"), utils::tail, 2)
     x <- sapply(x, paste, collapse=":")
     x[x == "NA"] <- NA
     
@@ -339,7 +339,7 @@ validateImport <- function(field, meta_data, records, ids,
     #* convert times to character to ensure valid format
     x <- as.character(x)
     w <- which(!grepl("(\\d{2}:\\d{2}:00|\\d{2}:\\d{2})", x) & !is.na(x))
-    x <- sapply(strsplit(x, ":"), utils::head, 2)
+    x <- lapply(strsplit(x, ":"), utils::head, 2)
     x <- sapply(x, paste, collapse=":")
     if (length(w) > 0){
       not_time_mmss_msg <- records[w, c(ids, field), drop=FALSE]
@@ -372,7 +372,7 @@ validateImport <- function(field, meta_data, records, ids,
     
     # Convert to character again for upload.
     x <- as.character(x)
-    x <- sapply(strsplit(x, ":"), utils::head, 2)
+    x <- lapply(strsplit(x, ":"), utils::head, 2)
     x <- sapply(x, paste, collapse=":")
     x[x == "NA"] <- NA
     


### PR DESCRIPTION
When there are no NA, 'sapply' returns a matrix rather than a list. The subsequent 'sapply' then fails and does not return the expected concatenated strings (hh:mm or mm:ss).

Using 'lapply' followed by 'sapply' first returns a list that is then simplified to a vector by 'sapply'.