### PR TITLE
Alternate approach to reordering field names

### DIFF
--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -107,8 +107,6 @@ exportRecords_offline <-
     # Create a dataframe of these extra variable names, storing their original index.
     x_field_names_df <- data.frame(index=1:ncol(x), field_name=x_field_names, stringsAsFactors = FALSE)
     x_field_names_extra_df <- x_field_names_df[x_field_names_df$field_name %in% x_field_names_extra, ]
-    #x_field_names_df <- x_field_names_df[! x_field_names_df$field_name %in% x_field_names_extra, ]
-    #x <- x[, as.numeric(rownames(x_field_names_df))]
     
     # Replace the index with the index of previous item for use with append()'s 'after' argument.
     x_field_names_extra_df$index <- x_field_names_extra_df$index - 1

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -37,10 +37,10 @@ exportRecords_offline <-
           length(which(meta_data$field_name %in% fields)) == length(fields)){
         field_names <- unique(c(fields))
         .params[['fields']] = paste(fields,collapse=',')
-      }
+      } 
       else #* found non-existent fields
         stop(paste("Non-existent fields:", paste(fields[!fields %in% meta_data$field_name], collapse=", "), sep=" "))
-    }
+    } 
     else{ #* fields were not provided, default to all fields.
       field_names <- meta_data$field_name
     }
@@ -96,7 +96,7 @@ exportRecords_offline <-
     #* return field_names to a vector
     field_names <- unlist(field_names)
     
-    x <- utils::read.csv(datafile, stringsAsFactors=FALSE, na.strings="", header=FALSE, skip=1)#[, field_names, drop=FALSE]
+    x <- utils::read.csv(datafile, stringsAsFactors=FALSE, na.strings="", header=TRUE)#[, field_names, drop=FALSE]
     
     # Find the original variable names in the record form dataset.
     x_field_names <- as.vector(t(utils::read.csv(datafile, stringsAsFactors=FALSE, na.strings="", header=FALSE, colClasses='character', nrows=1)))
@@ -107,17 +107,19 @@ exportRecords_offline <-
     # Create a dataframe of these extra variable names, storing their original index.
     x_field_names_df <- data.frame(index=1:ncol(x), field_name=x_field_names, stringsAsFactors = FALSE)
     x_field_names_extra_df <- x_field_names_df[x_field_names_df$field_name %in% x_field_names_extra, ]
-
+    #x_field_names_df <- x_field_names_df[! x_field_names_df$field_name %in% x_field_names_extra, ]
+    #x <- x[, as.numeric(rownames(x_field_names_df))]
+    
     # Replace the index with the index of previous item for use with append()'s 'after' argument.
     x_field_names_extra_df$index <- x_field_names_extra_df$index - 1
 
-    #lapply(field_names,
-    #       function(i) 
-    #       {
-    #         x[[i]] <<- fieldToVar(as.list(meta_data[meta_data$field_name==sub("___[a-z,A-Z,0-9,_]+", "", i),]), 
-    #                               x[[i]],factors,dates, checkboxLabels, vname=i)
-    #       }
-    #)
+    lapply(field_names,
+           function(i) 
+           {
+             x[[i]] <<- fieldToVar(as.list(meta_data[meta_data$field_name==sub("___[a-z,A-Z,0-9,_]+", "", i),]), 
+                                   x[[i]],factors,dates, checkboxLabels, vname=i)
+           }
+    )
     
     # Insert the extra field names into the field_names vector in the correct position.
     # Similarly, insert NA into field_labels for those fields not in this vector.

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -37,11 +37,11 @@ exportRecords_offline <-
           length(which(meta_data$field_name %in% fields)) == length(fields)){
         field_names <- unique(c(fields))
         .params[['fields']] = paste(fields,collapse=',')
-      }
-      else #* found non-existent fields
+      } else {
+        #* found non-existent fields
         stop(paste("Non-existent fields:", paste(fields[!fields %in% meta_data$field_name], collapse=", "), sep=" "))
-    }
-    else{ #* fields were not provided, default to all fields.
+    } else {
+      #* fields were not provided, default to all fields.
       field_names <- meta_data$field_name
     }
     
@@ -111,30 +111,32 @@ exportRecords_offline <-
     # Replace the index with the index of previous item for use with append()'s 'after' argument.
     x_field_names_extra_df$index <- x_field_names_extra_df$index - 1
 
-    lapply(field_names,
-           function(i) 
-           {
-             x[[i]] <<- fieldToVar(as.list(meta_data[meta_data$field_name==sub("___[a-z,A-Z,0-9,_]+", "", i),]), 
-                                   x[[i]],factors,dates, checkboxLabels, vname=i)
-           }
-    )
+    #lapply(field_names,
+    #       function(i) 
+    #       {
+    #         x[[i]] <<- fieldToVar(as.list(meta_data[meta_data$field_name==sub("___[a-z,A-Z,0-9,_]+", "", i),]), 
+    #                               x[[i]],factors,dates, checkboxLabels, vname=i)
+    #       }
+    #)
     
-    if (labels) Hmisc::label(x[, field_names], self=FALSE) <- field_labels
-
     # Insert the extra field names into the field_names vector in the correct position.
+    # Similarly, insert NA into field_labels for those fields not in this vector.
     if (nrow(x_field_names_extra_df) != 0) {
         for (i in 1:nrow(x_field_names_extra_df)) {
             field_names <- append(field_names, x_field_names_extra_df[i, 'field_name'], after=x_field_names_extra_df[i, 'index'])
+            field_labels <- append(field_labels, NA, after=x_field_names_extra_df[i, 'index'])
         }
     }
 
     # Rename the fields of x using the merged field_names vector.
     names(x) <- field_names
     
+    if (labels) Hmisc::label(x[, field_names], self=FALSE) <- field_labels
+    
     # convert survey timestamps to dates
     if (dates)
     {
-      survey_date <- survey_fields[grepl("_timestamp$", field_names)]
+      survey_date <- field_names[grepl("_timestamp$", field_names)]
       x[survey_date] <- 
         lapply(x[survey_date],
                function(s) 

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -109,7 +109,7 @@ exportRecords_offline <-
     if ("redcap_event_name" %in% names(x)) field_names <- c(field_names[1], "redcap_event_name", field_names[-1])
     
     # get the survey field names.
-    survey_fields <- names(x)[grepl("_survey_(identifier|timestamp)$", 
+    survey_fields <- names(x)[grepl("(_survey_identifier|_timestamp)$",
                                     names(x))]
     
     # convert survey timestamps to dates

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -144,6 +144,7 @@ exportRecords_offline <-
                function(s) 
                {
                  s[s == "[not completed]"] <- NA
+                 s[s == "0000-00-00 00:00:00"] <- NA
                  as.POSIXct(s)
                })
     }

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -38,12 +38,10 @@ exportRecords_offline <-
         field_names <- unique(c(fields))
         .params[['fields']] = paste(fields,collapse=',')
       }
-      else {
-        #* found non-existent fields
+      else #* found non-existent fields
         stop(paste("Non-existent fields:", paste(fields[!fields %in% meta_data$field_name], collapse=", "), sep=" "))
-    } 
-    else {
-      #* fields were not provided, default to all fields.
+    }
+    else{ #* fields were not provided, default to all fields.
       field_names <- meta_data$field_name
     }
     

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -37,10 +37,12 @@ exportRecords_offline <-
           length(which(meta_data$field_name %in% fields)) == length(fields)){
         field_names <- unique(c(fields))
         .params[['fields']] = paste(fields,collapse=',')
-      } else {
+      }
+      else {
         #* found non-existent fields
         stop(paste("Non-existent fields:", paste(fields[!fields %in% meta_data$field_name], collapse=", "), sep=" "))
-    } else {
+    } 
+    else {
       #* fields were not provided, default to all fields.
       field_names <- meta_data$field_name
     }


### PR DESCRIPTION
Started using the approach suggested in #81 for reordering field names in exportRecords_offline.R. This is working with my data set. However, this requires that the header row is included in the CSV. Then refactored to be as close to the original nutterb repo as possible. At this point, the only main differences are the the CSVs need to have their headers and that the extra fields in the record form data do not have to be guessed  based on conventions. The benefits are that this function finally works with our data and with more reasonable changes to the code compared to my earlier pull request. I'll send my sample dataset by email to nutterb for testing. I do not have access to the project's web UI in REDCap, just to the API. We need to be able to bring in REDCap data from CSV and from the equivalent datasets in a SQL database. That's why it is important to us that we have an "offline" function like this.