### PR TITLE
Account for additional metadata fields in message

### DIFF
--- a/R/importRecords.R
+++ b/R/importRecords.R
@@ -191,10 +191,11 @@ importRecords.redcapApiConnection <- function(rcon, data,
               "redcap_data_access_group"))
   if (length(w.remove)) data <- data[-w.remove]
   
-  if (!all(names(data) %in% c(with_complete_fields, "redcap_event_name", "redcap_repeat_instrument", "redcap_repeat_instance")))
+  unrecognized_names <- !(names(data) %in% c(with_complete_fields, "redcap_event_name", "redcap_repeat_instrument", "redcap_repeat_instance"))
+  if (any(unrecognized_names))
   {
     coll$push(paste0("The variables ", 
-                     paste(names(data)[!names(data) %in% with_complete_fields], collapse=", "),
+                     paste(names(data)[unrecognized_names], collapse=", "),
                      " do not exist in the REDCap Data Dictionary"))
   }
   


### PR DESCRIPTION
Don't warn about redcap_event_name, redcap_repeat_instrument, or redcap_repeat_instance
not being in the data dictionary.