### PR TITLE
Update validateImport_methods.R

### DIFF
--- a/R/validateImport_methods.R
+++ b/R/validateImport_methods.R
@@ -442,7 +442,8 @@ validate_import_email <- function(x, field_name, logfile)
     field_name = field_name,
     indices = w,
     message = paste0("Value(s) are not valid e-mail addresses.\n",
-                     "Values not imported.")
+                     "Values not imported."),
+    logfile = logfile
   )
   
   x[w] <- NA


### PR DESCRIPTION
Adding the logfile argument to the print_validation_message() in the validate_import_email() function to get solve the follow error that was received: 

Error in print_validation_message(field_name = field_name, indices = w,  : 
  argument "logfile" is missing, with no default