### PR TITLE
Convert the records vector into array in deleteRecords

### DIFF
--- a/R/deleteRecords.R
+++ b/R/deleteRecords.R
@@ -66,11 +66,12 @@ deleteRecords.redcapApiConnection <- function(rcon, records, arms = NULL, ...,
   
   body <- list(token = rcon$token,
                content = "record",
-               action = "delete",
-               records = paste0(records, collapse = ","))
+               action = "delete")
   
-  print(body[["records"]])
-  
+  for(i in records) {
+    body[[paste0("records[", i, "]")]] = i
+  }
+
   if (!is.null(arms))
     body[["arms"]] <- paste0(arms, collapse = ",")
   

--- a/R/deleteRecords.R
+++ b/R/deleteRecords.R
@@ -68,9 +68,11 @@ deleteRecords.redcapApiConnection <- function(rcon, records, arms = NULL, ...,
                content = "record",
                action = "delete")
   
-  for(i in records) {
-    body[[paste0("records[", i, "]")]] = i
-  }
+  records <- lapply(records, 
+                      identity)
+  names(records) <- sprintf("records[%s]", records)
+  
+  body <- c(body, records)
 
   if (!is.null(arms))
     body[["arms"]] <- paste0(arms, collapse = ",")


### PR DESCRIPTION
This PR allows `deleteRecords` to use a vector of record IDs in the `records` param.