### PR TITLE
Eliminate crash on unmapped suffix

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: redcapAPI
 Type: Package
 Title: Interface to 'REDCap'
-Version: 2.3.1
+Version: 2.3.2
 Authors@R: c(
     person("Benjamin", "Nutter", email = "benjamin.nutter@gmail.com", 
            role = c("aut", "ctb", "cre")),

--- a/NEWS
+++ b/NEWS
@@ -1,9 +1,11 @@
+
 ## Changes in Version 2.2 (no scheduled date)
 * BREAKING CHANGE: The `dev_allocate` and `prod_allocate` elements of the 
   object returned by `allocationTable` have been named `dev_allocation` and 
   `prod_allocation`, respectively.  
 * Bug fix: `importRecords` now handles data with repeating forms correctly.
 * New feature: UTF-8 Characters may be stripped from the data dictionary.
+* Bug fix: Unmapped suffixes do not cause crashes, only warnings.
 
 ## Change up to Version 2.1 (2018-03-03)
 * Bug fix: Add `[form]_complete` fields

--- a/NEWS
+++ b/NEWS
@@ -1,11 +1,12 @@
+## Changes in Versino 2.3
+* Bug fix: Unmapped suffixes do not cause crashes, only warnings.
 
-## Changes in Version 2.2 (no scheduled date)
+## Changes in Version 2.2
 * BREAKING CHANGE: The `dev_allocate` and `prod_allocate` elements of the 
   object returned by `allocationTable` have been named `dev_allocation` and 
   `prod_allocation`, respectively.  
 * Bug fix: `importRecords` now handles data with repeating forms correctly.
 * New feature: UTF-8 Characters may be stripped from the data dictionary.
-* Bug fix: Unmapped suffixes do not cause crashes, only warnings.
 
 ## Change up to Version 2.1 (2018-03-03)
 * Bug fix: Add `[form]_complete` fields

--- a/R/exportRecords.R
+++ b/R/exportRecords.R
@@ -382,7 +382,11 @@ exportRecords.redcapApiConnection <-
       mapply(nm = suffixed$name_suffix,
              lab = suffixed$label_suffix,
              FUN = function(nm, lab){
-               labelVector::set_label(x[[nm]], lab)
+               if(is.null(x[[nm]])){
+                  warning("Missing field for suffix ", nm)
+               } else {
+                  labelVector::set_label(x[[nm]], lab)
+               }
              },
              SIMPLIFY = FALSE)
   }

--- a/R/exportRecords_offline.R
+++ b/R/exportRecords_offline.R
@@ -113,7 +113,11 @@ exportRecords_offline <- function(dataFile, metaDataFile,
       mapply(nm = suffixed$name_suffix,
              lab = suffixed$label_suffix,
              FUN = function(nm, lab){
-               labelVector::set_label(x[[nm]], lab)
+               if(is.null(x[[nm]])){
+                 warning("Missing field for suffix ", nm)
+               } else {
+                 labelVector::set_label(x[[nm]], lab)
+               }
              },
              SIMPLIFY = FALSE)
   }

--- a/R/exportReports.R
+++ b/R/exportReports.R
@@ -170,7 +170,11 @@ exportReports.redcapApiConnection <- function(rcon, report_id, factors = TRUE, l
       mapply(nm = suffixed$name_suffix,
              lab = suffixed$label_suffix,
              FUN = function(nm, lab){
-               labelVector::set_label(x[[nm]], lab)
+               if(is.null(x[[nm]])){
+                 warning("Missing field for suffix ", nm)
+               } else {
+                 labelVector::set_label(x[[nm]], lab)
+               }
              },
              SIMPLIFY = FALSE)
   }

--- a/R/recodeCheck.R
+++ b/R/recodeCheck.R
@@ -84,7 +84,11 @@ recodeCheck <- function(df, vars,
     mapply(nm = checkbox,
            lab = var.label,
            FUN = function(nm, lab){
-             labelVector::set_label(df[[nm]], lab)
+             if(is.null(df[[nm]])){
+               warning("Missing field for suffix ", nm)
+             } else {
+               labelVector::set_label(df[[nm]], lab)
+             }
            },
            SIMPLIFY = FALSE)
   


### PR DESCRIPTION
This turns an unmapped suffix into a warning instead